### PR TITLE
add support for cross compilation to iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,11 @@ if(ANDROID)
   message(STATUS "Cross compiling for Android")
 endif()
 
+if(IOS)
+  add_definitions(-DIOS)
+  message(STATUS "Cross compiling for iOS")
+endif()
+
 # For building the CHOLMOD based solvers
 option(G2O_USE_CHOLMOD "Build g2o with CHOLMOD support" ON)
 find_package(Cholmod)
@@ -302,8 +307,12 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   message(STATUS "Compiling with Clang")
 
   # activate all warnings
-  set(g2o_C_FLAGS "${g2o_C_FLAGS} -Wall -O3 -fPIC -march=native")
-  set(g2o_CXX_FLAGS "${g2o_CXX_FLAGS} -Wall -O3 -fPIC -march=native")
+  set(g2o_C_FLAGS "${g2o_C_FLAGS} -Wall -O3 -fPIC")
+  set(g2o_CXX_FLAGS "${g2o_CXX_FLAGS} -Wall -O3 -fPIC")
+  if(NOT IOS)
+    set(g2o_C_FLAGS "${g2o_C_FLAGS} -march=native")
+    set(g2o_CXX_FLAGS "${g2o_CXX_FLAGS} -march=native")
+  endif()
 endif()
 
 if(MSVC)

--- a/g2o/stuff/filesys_tools.cpp
+++ b/g2o/stuff/filesys_tools.cpp
@@ -133,8 +133,8 @@ std::vector<std::string> getFilesByPattern(const char* pattern)
     } while (FindNextFile(hFind, &FData));
     FindClose(hFind);
   }
-  
-#elif (defined (UNIX) || defined (CYGWIN)) && !defined(ANDROID)
+
+#elif (defined (UNIX) || defined (CYGWIN)) && !defined(ANDROID) && !defined(IOS)
 
   wordexp_t p;
   wordexp(pattern, &p, 0);
@@ -153,7 +153,7 @@ std::vector<std::string> getFilesByPattern(const char* pattern)
   result.reserve(p.we_wordc);
   for (size_t i = 0; i < p.we_wordc; ++i)
     result.push_back(p.we_wordv[i]);
-  
+
   wordfree(&p);
 
 #endif

--- a/g2o/stuff/string_tools.cpp
+++ b/g2o/stuff/string_tools.cpp
@@ -123,7 +123,7 @@ int strPrintf(std::string& str, const char* fmt, ...)
 
 std::string strExpandFilename(const std::string& filename)
 {
-#if (defined (UNIX) || defined(CYGWIN)) && !defined(ANDROID)
+#if (defined (UNIX) || defined(CYGWIN)) && !defined(ANDROID) && !defined(IOS)
   string result = filename;
   wordexp_t p;
 


### PR DESCRIPTION
### Summary

This PR adds a preprocessor definition `IOS` when cross compiling for iOS so that the build behaves similar to the Android build. This makes it possible to compile `g2o` for iOS